### PR TITLE
Link only relevant module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ or
 
 ### Mostly automatic installation
 
-`$ react-native link`
+`$ react-native link react-native-file-viewer`
 
 ### Manual installation
 


### PR DESCRIPTION
When running `react-native link` without module name, the tool will scan all the modules and link them all. Unfortunately since this is not a very reliable tool, it will often relink multiple times the same modules. So in this change, the command will link only the current module.