### PR TITLE
Add typing to `onDismiss`.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ interface RNFileViewerOptions {
     displayName?: string;
     showAppsSuggestions?: boolean;
     showOpenWithDialog?: boolean;
-    onDismiss?();
+    onDismiss?(): any;
 }
 
 export function open(


### PR DESCRIPTION
I was running into the following TypeScript error:
`node_modules/react-native-file-viewer/index.d.ts(5,5): error TS7010: 'onDismiss', which lacks return-type annotation, implicitly has an 'any' return type.`

This fixes the error.