### PR TITLE
Android X support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Native file viewer for react-native. Preview any type of file supported by the m
 
 **Windows**: Start the default app associated with the specified file.
 
+## Android X Breaking changes
+
+The library supports [Android X](https://developer.android.com/jetpack/androidx/) and React Native 0.60+.
+
+If you're using **React Native < 0.60**, please append the following snippet to your `android/app/build.gradle` file:
+
+```
+preBuild.doFirst {
+    ant.replaceregexp(match:'androidx.core.content.', replace:'android.support.v4.content.', flags:'g', byline:true) {
+        fileset(dir: '../../node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer', includes: '*.java')
+    }
+}
+```
+
 ## Getting started
 
 `$ npm install react-native-file-viewer --save`

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,12 +5,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 23)
-    buildToolsVersion safeExtGet('buildToolsVersion', '25.0.0')
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 22)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }

--- a/android/src/main/java/com/vinzscam/reactnativefileviewer/FileProvider.java
+++ b/android/src/main/java/com/vinzscam/reactnativefileviewer/FileProvider.java
@@ -1,5 +1,5 @@
 package com.vinzscam.reactnativefileviewer;
 
-public class FileProvider extends android.support.v4.content.FileProvider {
+public class FileProvider extends androidx.core.content.FileProvider {
 
 }

--- a/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java
+++ b/android/src/main/java/com/vinzscam/reactnativefileviewer/RNFileViewerModule.java
@@ -5,7 +5,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 import android.webkit.MimeTypeMap;
 
 import com.facebook.react.bridge.ActivityEventListener;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-file-viewer",
-  "version": "1.0.15",
+  "version": "2.0.0",
   "description": "Native file viewer for react-native",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR migrates the library to Android X and React Native 0.60+.
If you still want to use an old version of React Native, a quick fix might be to append the following snippet to your `android/app/build.gradle` file:

```
preBuild.doFirst {
    ant.replaceregexp(match:'androidx.core.content.', replace:'android.support.v4.content.', flags:'g', byline:true) {
        fileset(dir: '../../node_modules/react-native-file-viewer/android/src/main/java/com/vinzscam/reactnativefileviewer', includes: '*.java')
    }
}
```