### PR TITLE
🐛Fix:Failed to find configured root that contains

### DIFF
--- a/android/src/main/res/xml/file_viewer_provider_paths.xml
+++ b/android/src/main/res/xml/file_viewer_provider_paths.xml
@@ -4,4 +4,5 @@
     <external-files-path name="external_files" path="" />
     <external-path name="external" path="." />
     <cache-path name="cache" path="/" />
+	<root-path name="root" path="." />
 </paths>


### PR DESCRIPTION
This fixes the bug: "Failed to find configured root that contains" when you try to open a file from external storage.