### PR TITLE
Check on iOS if can preview before opening

### DIFF
--- a/ios/RNFileViewerManager.m
+++ b/ios/RNFileViewerManager.m
@@ -118,9 +118,13 @@ RCT_EXPORT_METHOD(open:(NSString *)path invocation:(nonnull NSNumber *)invocatio
     controller.delegate = self;
 
     typeof(self) __weak weakSelf = self;
-    [[RNFileViewer topViewController] presentViewController:controller animated:YES completion:^{
-        [weakSelf sendEventWithName:OPEN_EVENT body: @{@"id": invocationId}];
-    }];
+    if([QLPreviewController canPreviewItem:file]) {
+        [[RNFileViewer topViewController] presentViewController:controller animated:YES completion:^{
+            [weakSelf sendEventWithName:OPEN_EVENT body: @{@"id": invocationId}];
+        }];
+    } else {
+        [weakSelf sendEventWithName:OPEN_EVENT body: @{@"id": invocationId, @"error": @"File not supported"}];
+    }
 }
 
 @end


### PR DESCRIPTION
Closes #135 

On Android if the file cannot be opened the promise is rejected.

This PR adds the same behaviour to iOS by checking if the file can be opened first.